### PR TITLE
Feature/aws txt detail page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,10 @@ gem 'devise-i18n'
 gem 'activeadmin'
 gem 'devise-bootstrap-views'
 
+#Markdownとシンタックスハイライトの導入
+gem 'redcarpet', '~>2.3.0'
+gem 'coderay'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,6 +202,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (2.3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -259,6 +260,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -271,6 +273,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n
+  redcarpet (~> 2.3.0)
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,3 @@
-/*
- *= require_tree .
- *= require_self
- */
-
 @import "bootstrap/scss/bootstrap";
 
 .base-container {
@@ -10,4 +5,20 @@
   margin: 0 auto;
   padding: 1rem;
   text-align: center;
+}
+
+.aws-text-container {
+  text-align: left;
+}
+
+.aws-title {
+  padding-top: 7rem;
+  font-size: 1.75rem;
+  font-weight: bold;
+}
+
+.aws-body h2 {
+  font-size: 1.7rem;
+  font-weight: bold;
+  padding: 30px 0 15px 0;
 }

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,4 +2,8 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts = AwsText.all
   end
+
+  def show
+    @aws_text = AwsText.find(params[:id])
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+      language = language.split(":")[0] if language.present?
+
+      case language.to_s
+      when "rb"
+        lang = :ruby
+      when "yml"
+        lang = :yaml
+      when "css"
+        lang = :css
+      when "html"
+        lang = :html
+      when ""
+        lang = :md
+      else
+        lang = language
+      end
+
+      CodeRay.scan(code, lang).div
+    end
+  end
+
+  def markdown(text)
+    html_render = HTMLwithCoderay.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: "nofollow", target: "_blank" },
+    )
+    options = {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+    }
+    markdown = Redcarpet::Markdown.new(html_render, options)
+    markdown.render(text)
+  end
 end

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -23,7 +23,7 @@
           <% @aws_texts.each.with_index(1) do |text, i| %>
             <tr>
               <th scope="row" class="font-weight-normal"><%= i %></th>
-              <td class="text-left pl-5"><%= link_to "#{text.title}", "#" %></td>
+              <td class="text-left pl-5"><%= link_to "#{text.title}", aws_text_path(text) %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,2 @@
+<%= markdown(@aws_text.title).html_safe %>
+<%= markdown(@aws_text.content).html_safe %>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,2 +1,8 @@
-<%= markdown(@aws_text.title).html_safe %>
-<%= markdown(@aws_text.content).html_safe %>
+<div class="aws-text-container">
+  <div class="aws-title">
+    <%= markdown(@aws_text.title).html_safe %>
+  </div>
+  <div class="aws-body">
+    <%= markdown(@aws_text.content).html_safe %>
+  </div>
+</div>


### PR DESCRIPTION
### AWSテキスト教材の詳細ページの実装
・Gem「redcarpet」「coderay」を`bundle install`
・`app/helpers/application_helper.rb`にMarkdown導入のための記述を追記
・showアクション及び対応するビューファイル`aws_texts/show.html.erb`を実装。
※コードの表示はデフォルトのままです。

＜参考資料＞
・https://arcane-gorge-21903.herokuapp.com/texts/224(逆転教材)

