### PR TITLE
質問一覧、詳細ページへのView数の表示を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'devise-bootstrap-views'
 gem 'redcarpet', '~>2.3.0'
 gem 'coderay'
 
+#質問詳細ページへのPV数の実装
+gem 'impressionist'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       activesupport (>= 4.1)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    impressionist (2.0.0)
+      nokogiri (~> 1)
     inherited_resources (1.11.0)
       actionpack (>= 5.0, < 6.1)
       has_scope (~> 0.6)
@@ -264,6 +266,7 @@ DEPENDENCIES
   devise
   devise-bootstrap-views
   devise-i18n
+  impressionist
   jbuilder (~> 2.7)
   kaminari
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,7 +27,7 @@
   h3 {
     font-size: 20px;
   }
-  
+
   .title {
     padding-top: 50px;
   }
@@ -94,12 +94,14 @@
   color: #888888;
 }
 
-.question_title, .question_date {
-  width: 50%; 
+.question_title,
+.question_date {
+  width: 50%;
 }
 
 .field_with_errors {
   display: contents;
+
   textarea {
     @extend .is-invalid;
   }
@@ -107,7 +109,7 @@
 
 .container {
   padding: 20px 0px 10px 0px;
-  text-align :left;
+  text-align: left;
   width: 800px;
 
   p {
@@ -147,14 +149,30 @@
   padding: 30px 0;
 }
 
-.form-control{
+.form-control {
   max-width: 768px;
   margin-right: auto;
   margin-left: auto;
 }
 
 .btn-primary {
-  max-width: 768px; 
+  max-width: 768px;
   margin-right: auto;
   margin-left: auto;
+}
+
+//質問詳細ページのview数の表示
+.view-contain {
+  position: relative;
+
+  & .page-views {
+    display: inline-block;
+    position: absolute;
+    left: 80%;
+    height: 31px;
+    padding: 0 5px;
+    border: 1.5px solid #005FFF;
+    background-color: #CCFFFF;
+    border-radius: 10% 10%;
+  }
 }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -6,6 +6,7 @@ class QuestionsController < ApplicationController
   
   def show
     @question = Question.find(params[:id])
+    impressionist(@question, nil, :unique => [:session_hash])
     @solutions = Solution.where(question_id: @question.id)
     @solution = @question.solutions.new
   end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,4 +1,5 @@
 class Question < ApplicationRecord
+  is_impressionable counter_cache: true
   has_many :solutions, dependent: :destroy
   validates :title, presence: true
   validates :detail, presence: true

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -27,7 +27,7 @@
                 <div class="col-md-5">
                   <div class="info text-right">
                     <p><%= question.created_at.strftime("%Y年%m月%d日") %></p>
-                    <p><%= "#{0} Views" %></p>
+                    <p><%= question.impressions_count %>Views</p>
                   </div>
                 </div>
               </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,4 +1,7 @@
 <section id="question">
+  <div class="view-contain">
+    <span class="page-views"><%= @question.impressions_count %> Views</span>
+  </div>
   <div class="title">
     <h3>【質問】</h3>
     <p><%= markdown(@question.title).html_safe%></p>

--- a/config/initializers/impression.rb
+++ b/config/initializers/impression.rb
@@ -1,0 +1,8 @@
+# Use this hook to configure impressionist parameters
+#Impressionist.setup do |config|
+  # Define ORM. Could be :active_record (default), :mongo_mapper or :mongoid
+  # config.orm = :active_record
+#end
+
+
+

--- a/db/migrate/20200825230657_create_impressions_table.rb
+++ b/db/migrate/20200825230657_create_impressions_table.rb
@@ -1,0 +1,32 @@
+class CreateImpressionsTable < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table :impressions, :force => true do |t|
+      t.string :impressionable_type
+      t.integer :impressionable_id
+      t.integer :user_id
+      t.string :controller_name
+      t.string :action_name
+      t.string :view_name
+      t.string :request_hash
+      t.string :ip_address
+      t.string :session_hash
+      t.text :message
+      t.text :referrer
+      t.text :params
+      t.timestamps
+    end
+    add_index :impressions, [:impressionable_type, :message, :impressionable_id], :name => "impressionable_type_message_index", :unique => false, :length => {:message => 255 }
+    add_index :impressions, [:impressionable_type, :impressionable_id, :request_hash], :name => "poly_request_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :ip_address], :name => "poly_ip_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :session_hash], :name => "poly_session_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:request_hash], :name => "controlleraction_request_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:ip_address], :name => "controlleraction_ip_index", :unique => false
+    add_index :impressions, [:controller_name,:action_name,:session_hash], :name => "controlleraction_session_index", :unique => false
+    add_index :impressions, [:impressionable_type, :impressionable_id, :params], :name => "poly_params_request_index", :unique => false, :length => {:params => 255 }
+    add_index :impressions, :user_id
+  end
+
+  def self.down
+    drop_table :impressions
+  end
+end

--- a/db/migrate/20200826003509_add_column_to_questions.rb
+++ b/db/migrate/20200826003509_add_column_to_questions.rb
@@ -1,0 +1,5 @@
+class AddColumnToQuestions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :questions, :impressions_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_19_132429) do
+ActiveRecord::Schema.define(version: 2020_08_26_003509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,11 +41,45 @@ ActiveRecord::Schema.define(version: 2020_08_19_132429) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "all_movies", force: :cascade do |t|
+    t.string "category", null: false
+    t.string "title", null: false
+    t.string "url", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "aws_texts", force: :cascade do |t|
     t.string "title"
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "impressions", force: :cascade do |t|
+    t.string "impressionable_type"
+    t.integer "impressionable_id"
+    t.integer "user_id"
+    t.string "controller_name"
+    t.string "action_name"
+    t.string "view_name"
+    t.string "request_hash"
+    t.string "ip_address"
+    t.string "session_hash"
+    t.text "message"
+    t.text "referrer"
+    t.text "params"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
+    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
+    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
+    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
+    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index"
+    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
+    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
+    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index"
+    t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
   create_table "lines", force: :cascade do |t|
@@ -69,6 +103,7 @@ ActiveRecord::Schema.define(version: 2020_08_19_132429) do
     t.text "detail", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "impressions_count", default: 0
   end
 
   create_table "solutions", force: :cascade do |t|


### PR DESCRIPTION
<impressionistを利用してview数の表示を実装>
①Gemファイルに`gem 'impressionist'`を記述し`bundle install`
②`rails g impressionist`コマンドを実行し、自動的に作成されたマイグレーションを実行　`rails db:migrate`
③questionsテーブルにimpression数をカウントするためのカラム`impressions_count`を追加
※詳細ページにのみ表示であれば、上記手順は必要なかったが、indexページにもview数を表示するため、カラムを追加
④Questionモデルに`is_impressionable counter_cache: true`を記述。
⑤各ページにてview数を表示。詳細ページのviewレイアウトのみ調整してます。