### PR TITLE
Feature/check

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -1,0 +1,14 @@
+class ChecksController < ApplicationController
+  def create
+    @movie=Movie.find_by(id: params[:movie_id])
+    Check.create(user_id:current_user.id,checkable:@movie)
+    redirect_back(fallback_location: movies_path)
+  end
+  
+  def destroy
+    @movie=Movie.find_by(id: params[:movie_id])
+    check=Check.find_by(user_id:current_user.id,checkable:@movie)
+    check.destroy
+    redirect_back(fallback_location: movies_path)
+  end
+end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -1,0 +1,5 @@
+class Check < ApplicationRecord
+  belongs_to :user
+  belongs_to :checkable, polymorphic: true
+  validates :user_id, uniqueness: { scope: [:checkable_type,:checkable_id] } 
+end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -2,6 +2,7 @@ class Movie < ApplicationRecord
   validates :title, presence: true
   validates :url, presence: true
   validates :category, presence: true
+  has_many :checks, as: :checkable
 
   SELECTION_MOVIIES = ["Basic", "Git", "Ruby", "Ruby on Rails"]
 
@@ -11,5 +12,9 @@ class Movie < ApplicationRecord
     else
       where(category: SELECTION_MOVIIES)
     end
+  end
+
+  def checked_by?(user)
+    checks.where(user_id:user.id).exists?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   has_many :favorite_solutions, through: :favorites, source: :soulution
+  has_many :checks
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -9,6 +9,11 @@
             </div>
           </div>
           <div class="card-body text-dark">
+            <%if movie.checked_by?(current_user)%>
+              <%= link_to "試聴済みを解除",movie_check_path(movie) , class:"btn btn-primary btn-block", method: :delete%>
+            <%else%>
+              <%= link_to "試聴済みにする",movie_check_path(movie)  ,class:"btn btn-secondary btn-block", method: :post%>
+            <%end%>
             <p class="card-text movie-title">Lv.<%= i %>：<%= movie.title %></p>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
       resource :favorite, only: [:create, :destroy]
     end
   end
-  resources :movies
+  resources :movies do
+    resource :check, only: [:create, :destroy]
+  end
 
   resources :texts
 

--- a/db/migrate/20200909003847_create_checks.rb
+++ b/db/migrate/20200909003847_create_checks.rb
@@ -1,0 +1,9 @@
+class CreateChecks < ActiveRecord::Migration[6.0]
+  def change
+    create_table :checks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :checkable, polymorphic: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_29_231435) do
+ActiveRecord::Schema.define(version: 2020_09_09_003847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,16 @@ ActiveRecord::Schema.define(version: 2020_08_29_231435) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "checks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "checkable_type"
+    t.bigint "checkable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["checkable_type", "checkable_id"], name: "index_checks_on_checkable_type_and_checkable_id"
+    t.index ["user_id"], name: "index_checks_on_user_id"
   end
 
   create_table "favorites", force: :cascade do |t|
@@ -107,8 +117,18 @@ ActiveRecord::Schema.define(version: 2020_08_29_231435) do
     t.integer "impressions_count", default: 0
   end
 
+  create_table "reads", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "readable_type"
+    t.bigint "readable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["readable_type", "readable_id"], name: "index_reads_on_readable_type_and_readable_id"
+    t.index ["user_id"], name: "index_reads_on_user_id"
+  end
+
   create_table "solutions", force: :cascade do |t|
-    t.text "content", null: false
+    t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "question_id"
@@ -135,7 +155,9 @@ ActiveRecord::Schema.define(version: 2020_08_29_231435) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "checks", "users"
   add_foreign_key "favorites", "solutions"
   add_foreign_key "favorites", "users"
+  add_foreign_key "reads", "users"
   add_foreign_key "solutions", "questions"
 end


### PR DESCRIPTION
38_読破・試聴済み機能の実装
・実際のアプリのように試聴済みのボタンを作成。読破機能は対応indexがカード表示になっていないので、試聴済み機能搭載後、実装。
・機能対応の為、checkモデルを作成。
・試聴済み、読破済み両方の機能に対応する為、checkモデルをポリモーフィック に。