### PR TITLE
AWSテキスト教材一覧ページの実装2

### DIFF
--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,4 +1,4 @@
-<div class="aws-text-container">
+<div class="table-container">
   <div class="aws-title">
     <%= markdown(@aws_text.title).html_safe %>
   </div>


### PR DESCRIPTION
修正目標

17_AWSテキスト教材一覧ページの実装で作成した一覧ページをcsvデータを用いて、
実際のページのように完成させる。

・lineタスクでテーブルの共通cssを作成してあるので、それを使用。
・lineページのレイアウトを参考。